### PR TITLE
[feat] Retrofit 초기 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -6,10 +9,17 @@ plugins {
     kotlin("kapt")
     id("com.google.dagger.hilt.android")
 }
+val properties = Properties()
+properties.load(FileInputStream(rootProject.file("local.properties")))
 
 android {
     namespace = "com.example.seoulgonggong"
     compileSdk = libs.versions.compileSdk.get().toInt()
+
+    //BuildConfig 클래스 생성
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
         applicationId = "com.example.seoulgonggong"
@@ -19,6 +29,7 @@ android {
         versionName = libs.versions.appVersion.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "BASE_URL", "\"http://openAPI.seoul.go.kr:8088/${properties["ACT_KEY"]}/\"")
     }
 
     buildTypes {
@@ -55,4 +66,14 @@ dependencies {
     // Hilt
     implementation(libs.hilt)
     kapt(libs.hiltKapt)
+
+    // Kotlinx-serialization
+    implementation(libs.kotlinx.serialization.json)
+
+    // Retrofit
+    implementation(libs.retrofit)
+    implementation(libs.retrofit2.kotlinx.serialization.converter) //Retrofit과 kotlin serialization 을 연동
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.core)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
         versionName = libs.versions.appVersion.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "BASE_URL", "\"http://openAPI.seoul.go.kr:8088/${properties["ACT_KEY"]}/\"")
+        buildConfigField("String", "SEOUL_OPEN_API_BASE_URL", "\"http://openAPI.seoul.go.kr:8088/${properties["ACT_KEY"]}/\"")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,8 +71,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     // Retrofit
-    implementation(libs.retrofit)
-    implementation(libs.retrofit2.kotlinx.serialization.converter) //Retrofit과 kotlin serialization 을 연동
+    implementation(libs.bundles.retrofit)
 
     // Coroutines
     implementation(libs.kotlinx.coroutines.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/seoulgonggong/data/Service.kt
+++ b/app/src/main/java/com/example/seoulgonggong/data/Service.kt
@@ -1,0 +1,12 @@
+package com.example.seoulgonggong.data
+
+import retrofit2.http.GET
+
+// 샘플 서비스 (이런 식으로 작성하면 된다는 예시)
+interface Service {
+
+    // url 은 이런 식으로 작성하면 될 것 같습니다 (예시는 공공서비스 데이터)
+    // 리턴타입은...미정...
+    @GET("/xml/ListPublicReservationSport/1/5/")
+    fun getDataSample()
+}

--- a/app/src/main/java/com/example/seoulgonggong/di/AppModule.kt
+++ b/app/src/main/java/com/example/seoulgonggong/di/AppModule.kt
@@ -13,15 +13,17 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType
 import javax.inject.Singleton
 
+
 @InstallIn(SingletonComponent::class)
 @Module
 object AppModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(): Retrofit {
+    @SeoulOpenApiRetrofit
+    fun provideSeoulOpenApiRetrofit(): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BuildConfig.BASE_URL)
+            .baseUrl(BuildConfig.SEOUL_OPEN_API_BASE_URL)
             .client(OkHttpClient.Builder().build())
             .addConverterFactory(Json.asConverterFactory(MediaType.parse("application/json")!!))
             .build()

--- a/app/src/main/java/com/example/seoulgonggong/di/AppModule.kt
+++ b/app/src/main/java/com/example/seoulgonggong/di/AppModule.kt
@@ -32,7 +32,7 @@ object AppModule {
     // 샘플 서비스 (이런 식으로 작성하면 된다는 예시)
     @Provides
     @Singleton
-    fun provideService(retrofit: Retrofit): Service {
+    fun provideService(@SeoulOpenApiRetrofit retrofit: Retrofit): Service {
         return retrofit.create(Service::class.java)
     }
 }

--- a/app/src/main/java/com/example/seoulgonggong/di/AppModule.kt
+++ b/app/src/main/java/com/example/seoulgonggong/di/AppModule.kt
@@ -1,0 +1,36 @@
+package com.example.seoulgonggong.di
+
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import com.example.seoulgonggong.BuildConfig
+import com.example.seoulgonggong.data.Service
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(OkHttpClient.Builder().build())
+            .addConverterFactory(Json.asConverterFactory(MediaType.parse("application/json")!!))
+            .build()
+    }
+
+    // 샘플 서비스 (이런 식으로 작성하면 된다는 예시)
+    @Provides
+    @Singleton
+    fun provideService(retrofit: Retrofit): Service {
+        return retrofit.create(Service::class.java)
+    }
+}

--- a/app/src/main/java/com/example/seoulgonggong/di/Qualifiers.kt
+++ b/app/src/main/java/com/example/seoulgonggong/di/Qualifiers.kt
@@ -1,0 +1,7 @@
+package com.example.seoulgonggong.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention
+annotation class SeoulOpenApiRetrofit

--- a/app/src/main/java/com/example/seoulgonggong/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/seoulgonggong/di/RepositoryModule.kt
@@ -1,0 +1,5 @@
+package com.example.seoulgonggong.di
+
+object RepositoryModule {
+    // Repository interface 구현체 제공
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,8 +29,17 @@ androidxTestEspresso = "3.5.1"
 glide = "4.16.0"
 
 # hilt
-hilt = "2.44"
+hilt = "2.48"
 
+# Kotlinx-serialization
+kotlinxSerializationJson = "1.6.3"
+
+# Retrofit
+retrofit = "2.11.0"
+retrofit2KotlinxSerializationConverter = "0.8.0"
+
+# Coroutines
+kotlinxCoroutinesCore = "1.8.1-Beta"
 
 [libraries]
 # AndroidX Libraries
@@ -39,6 +48,8 @@ appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat"
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 
 # Google Libraries
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 
 # Test Libraries
@@ -52,6 +63,8 @@ glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 # hilt
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hiltKapt = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
 
 [bundles]
 androidDefault = ["coreKtx", "appcompat", "constraintlayout", "material"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,5 +70,6 @@ retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit
 androidDefault = ["coreKtx", "appcompat", "constraintlayout", "material"]
 test = ["junit"]
 androidUnitTest = ["androidTestJunit", "androidxTestEspresso"]
+retrofit = ["retrofit", "retrofit2-kotlinx-serialization-converter"]
 
 [plugins]


### PR DESCRIPTION
## 📌 관련 이슈
- #4 

## 🛠️ 작업 내용
- [X] Retrofit, kotlinx-serialization, coroutines 라이브러리 의존성 추가
- [X] AppModule object 에서 Retrofit 객체 , 샘플 Service 객체 종속성 제공
- [X] BuildConfig 파일 생성 및 Retrofit 에서 쓰일 BASE_URL 저장 ([http://openapi.seoul.go.kr:8088/인증키/](http://openapi.seoul.go.kr:8088/%EC%9D%B8%EC%A6%9D%ED%82%A4/))
    -  구현하고 나니 드는 생각이,,,, 사실 저희는 빌드 타입이 release 타입 밖에 없기 때문에 굳이 BuildConfig 를 생성하지 않았어도 괜찮지 않나,,,하는 생각이 드네요 ㅎ (근데 구현한게 아까워서 + BuildConfig 에서 관리하는게 안전할 것 같아서 그냥 올립니다😱)
    -  단, local properties 에 핑구가 발급한 인증키 저장되어 있어야 함 

## 🎯 리뷰 포인트
- BuildConfig 파일이 생성되는 과정이 의아하신 분은(제가 그랬기 때문)... [노션](https://almondine-andesaurus-548.notion.site/BuildConfig-BASE_URL-6fce019773ab48da99f62438a196c729?pvs=4)을 참고해주세요(근데 진짜 대충 적음 진짜로)
- 해당 url로 통신은 제대로 작동하네요! html 형식의 response 는 타입을 어떻게 적어야될지 아직은 모르겠어서 서비스 메소드의 리턴값을 비워놓았습니다.
- 이미 작업이 진행된 분들은 충돌이 발생할수도 있을 것 같아요 😱

## 💻 미완료 태스크
