### PR TITLE
[feat] 공공서비스 필터 기능 구현 (#26)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:exported="false" />
         <activity
             android:name=".ui.sports_service_list.SportsServiceListActivity"
-            android:exported="false"
+            android:exported="true"
             />
         <activity
             android:name=".ui.sports_service_detail.SportsServiceDetailActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:exported="false" />
         <activity
             android:name=".ui.sports_service_list.SportsServiceListActivity"
-            android:exported="true"
+            android:exported="false"
             />
         <activity
             android:name=".ui.sports_service_detail.SportsServiceDetailActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,14 @@
             android:name=".ui.filter.service.SportsServiceFilterActivity"
             android:exported="false" />
         <activity
+            android:name=".ui.sports_service_list.SportsServiceListActivity"
+            android:exported="true"
+            />
+        <activity
+            android:name=".ui.sports_service_detail.SportsServiceDetailActivity"
+            android:exported="false"
+            />
+        <activity
             android:name=".ui.main.MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/seoulfitu/android/data/repository/DefaultSportsServiceRepository.kt
+++ b/app/src/main/java/com/seoulfitu/android/data/repository/DefaultSportsServiceRepository.kt
@@ -1,6 +1,5 @@
 package com.seoulfitu.android.data.repository
 
-import android.util.Log
 import com.seoulfitu.android.data.ERROR_MESSAGE_FAIL_RESULT
 import com.seoulfitu.android.data.ERROR_MESSAGE_NO_BODY
 import com.seoulfitu.android.data.model.mapper.toDomain
@@ -13,7 +12,6 @@ class DefaultSportsServiceRepository @Inject constructor(private val sportsServi
     SportsServiceRepository {
     override suspend fun getServices():Result<SportsServices>{
         val result = sportsServiceService.getServices()
-        Log.d("hkhk", "getServices: $result")
         if (result.isSuccessful){
             val body = result.body()?.toDomain()
                 ?: return Result.failure(IllegalStateException(ERROR_MESSAGE_NO_BODY))

--- a/app/src/main/java/com/seoulfitu/android/ui/filter/service/SportsServiceFilterActivity.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/filter/service/SportsServiceFilterActivity.kt
@@ -33,14 +33,12 @@ class SportsServiceFilterActivity : AppCompatActivity() {
             val cityOptions = binding.cvServiceFilterCity.getSelectedOptions()
             val typeOptions = binding.cvServiceFilterType.getSelectedOptions()
             val priceOptions = binding.cvServiceFilterPrice.getSelectedOptions()
-            val parkingOptions = binding.cvServiceFilterParking.getSelectedOptions()
             val statusOptions = binding.cvServiceFilterStatus.getSelectedOptions()
             val uiSelectedOptions =
                 UiSelectedOptions(
                     cities = cityOptions,
                     services = typeOptions,
                     price = priceOptions,
-                    parking = parkingOptions,
                     serviceStatus = statusOptions,
                 )
             setResult(RESULT_OK, getIntent(this, uiSelectedOptions))
@@ -61,15 +59,11 @@ class SportsServiceFilterActivity : AppCompatActivity() {
         }
         binding.cvServiceFilterPrice.apply {
             setFilterTitle(getString(R.string.filter_price_option_title))
-            addFilterOptionGroup(options, selected.price)
-        }
-        binding.cvServiceFilterParking.apply {
-            setFilterTitle(getString(R.string.filter_parking_option_title))
-            addFilterOptionGroup(options, selected.parking)
+            addFilterOptionGroup(priceOptions, selected.price)
         }
         binding.cvServiceFilterStatus.apply {
             setFilterTitle(getString(R.string.filter_status_option_title))
-            addFilterOptionGroup(options, selected.serviceStatus)
+            addFilterOptionGroup(statusOptions, selected.serviceStatus)
         }
     }
 
@@ -78,13 +72,13 @@ class SportsServiceFilterActivity : AppCompatActivity() {
             cvServiceFilterCity.clearSelection()
             cvServiceFilterType.clearSelection()
             cvServiceFilterPrice.clearSelection()
-            cvServiceFilterParking.clearSelection()
             cvServiceFilterStatus.clearSelection()
         }
     }
 
     companion object {
-        private val options = listOf("가능", "불가능")
+        private val priceOptions = listOf("유료", "무료")
+        private val statusOptions = listOf("접수중", "접수 종료", "예약 마감", "예약 일시중지", "안내중")
 
         fun getIntent(
             context: Context,

--- a/app/src/main/java/com/seoulfitu/android/ui/filter/service/SportsServiceFilterActivity.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/filter/service/SportsServiceFilterActivity.kt
@@ -8,7 +8,6 @@ import com.seoulfitu.android.R
 import com.seoulfitu.android.databinding.ActivitySportsServiceFilterBinding
 import com.seoulfitu.android.domain.model.Town
 import com.seoulfitu.android.ui.facility.SportsFacilityBottomSheetFragment.Companion.FILTER_KEY
-import com.seoulfitu.android.ui.filter.facility.SportsFacilityFilterActivity
 import com.seoulfitu.android.ui.filter.facility.SportsFacilityFilterActivity.Companion.emptySelectedOptions
 import com.seoulfitu.android.ui.uimodel.UiSelectedOptions
 import com.seoulfitu.android.ui.uimodel.UiSportsFacilityType
@@ -40,6 +39,7 @@ class SportsServiceFilterActivity : AppCompatActivity() {
                     services = typeOptions,
                     price = priceOptions,
                     serviceStatus = statusOptions,
+                    parking = listOf()
                 )
             setResult(RESULT_OK, getIntent(this, uiSelectedOptions))
             finish()
@@ -48,7 +48,7 @@ class SportsServiceFilterActivity : AppCompatActivity() {
 
     private fun initFilterOption() {
         val selected =
-            intent.getParcelableExtraCompat<UiSelectedOptions>(FILTER_KEY) ?: emptySelectedOptions
+            intent.getParcelableExtraCompat(FILTER_KEY) ?: emptySelectedOptions
         binding.cvServiceFilterCity.apply {
             setFilterTitle(getString(R.string.filter_city_option_title))
             addFilterOptionGroup(Town.entries.map { it.townName }, selected.cities)
@@ -84,7 +84,7 @@ class SportsServiceFilterActivity : AppCompatActivity() {
             context: Context,
             uiSelectedOptions: UiSelectedOptions,
         ): Intent {
-            return Intent(context, SportsFacilityFilterActivity::class.java).apply {
+            return Intent(context, SportsServiceFilterActivity::class.java).apply {
                 putExtra(FILTER_KEY, uiSelectedOptions)
             }
         }

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/SportsServiceDetailActivity.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/SportsServiceDetailActivity.kt
@@ -9,7 +9,6 @@ import com.seoulfitu.android.databinding.ActivitySportsServiceDetailBinding
 import com.seoulfitu.android.ui.sports_service_detail.viewmodel.SportsServiceDetailViewModel
 import com.seoulfitu.android.ui.uimodel.UiSportsService
 import com.seoulfitu.android.util.getParcelableExtraCompat
-import com.seoulfitu.android.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -26,25 +25,14 @@ class SportsServiceDetailActivity : AppCompatActivity() {
         observeSportsService()
     }
 
-    @Suppress("DEPRECATION")
     private fun getIntentExtra() {
         val sportsService = intent.getParcelableExtraCompat(EXTRA_KEY_SPORTS_SERVICE) ?: UiSportsService()
         viewModel.setSportsService(sportsService)
     }
 
     private fun observeSportsService() {
-        viewModel.sportsService.observe(this) {
-            when (it.isSuccess) {
-                true -> {
-                    binding.service = it.result
-                }
-                false -> {
-                    showToast(it.errorMessage)
-                }
-                else -> {
-                    // todo: 로딩화면
-                }
-            }
+        viewModel.service.observe(this) {
+            binding.service = it
         }
     }
 

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/uistate/SportsServiceDetailUiState.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/uistate/SportsServiceDetailUiState.kt
@@ -1,9 +1,0 @@
-package com.seoulfitu.android.ui.sports_service_detail.uistate
-
-import com.seoulfitu.android.ui.uimodel.UiSportsService
-
-data class SportsServiceDetailUiState(
-    val isSuccess:Boolean? = null,
-    val result:UiSportsService = UiSportsService(),
-    val errorMessage:String = ""
-)

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/viewmodel/SportsServiceDetailViewModel.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/viewmodel/SportsServiceDetailViewModel.kt
@@ -1,56 +1,26 @@
 package com.seoulfitu.android.ui.sports_service_detail.viewmodel
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.seoulfitu.android.domain.model.Coordinate
-import com.seoulfitu.android.domain.model.RegionWithCoordinate
-import com.seoulfitu.android.domain.repository.GeocodingRepository
-import com.seoulfitu.android.ui.sports_service_detail.uistate.SportsServiceDetailUiState
 import com.seoulfitu.android.ui.uimodel.UiSportsService
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
-class SportsServiceDetailViewModel @Inject constructor(
-    private val geocodingRepository: GeocodingRepository
-) : ViewModel() {
-    private val _sportService: MutableLiveData<SportsServiceDetailUiState> =
-        MutableLiveData(SportsServiceDetailUiState())
-    val sportsService: MutableLiveData<SportsServiceDetailUiState> = _sportService
+class SportsServiceDetailViewModel @Inject constructor() : ViewModel() {
+    private val _service: MutableLiveData<UiSportsService> = MutableLiveData(UiSportsService())
+    val service: LiveData<UiSportsService> = _service
 
     fun setSportsService(service: UiSportsService) {
-        viewModelScope.launch {
-            val result = geocodingRepository.reverseGeocode(
-                Coordinate(service.info.xCoordinate, service.info.yCoordinate)
+        _service.value = service.copy(
+            info = service.info.copy(
+                registrationStartDate = formatRegistrationDate(service.info.registrationStartDate),
+                registrationEndDate = formatRegistrationDate(service.info.registrationEndDate)
             )
-            result.onSuccess {
-                val regionWithCoordinate = it.values[0]
-                _sportService.value = _sportService.value?.copy(
-                    isSuccess = true,
-                    result = service.copy(
-                        info = service.info.copy(
-                            registrationStartDate = formatRegistrationDate(service.info.registrationStartDate),
-                            registrationEndDate = formatRegistrationDate(service.info.registrationEndDate),
-                            address = formatRegion(regionWithCoordinate)
-                        )
-                    )
-                )
-            }.onFailure {
-                _sportService.value = _sportService.value?.copy(
-                    errorMessage = it.message.toString()
-                )
-            }
-        }
-    }
-
-    private fun formatRegion(regionWithCoordinate: RegionWithCoordinate): String {
-        regionWithCoordinate.apply {
-            return "${area1.name} ${area2.name} ${area3.name} ${area4.name}"
-        }
+        )
     }
 
     private fun formatRegistrationDate(date: String): String {
@@ -62,7 +32,7 @@ class SportsServiceDetailViewModel @Inject constructor(
         return dateTime.format(stringFormatter)
     }
 
-    companion object{
+    companion object {
         private const val DATE_TIME_PARSING_PATTERN = "yyyy-MM-dd HH:mm:ss"
         private const val DATE_TIME_FORMAT_PATTERN = "yyyy.MM.dd HH:mm"
     }

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/SportsServiceListActivity.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/SportsServiceListActivity.kt
@@ -1,13 +1,18 @@
 package com.seoulfitu.android.ui.sports_service_list
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.widget.doOnTextChanged
 import com.seoulfitu.android.data.ERROR_MESSAGE_FAIL_RESULT
 import com.seoulfitu.android.databinding.ActivitySportsServiceListBinding
+import com.seoulfitu.android.ui.filter.service.SportsServiceFilterActivity
 import com.seoulfitu.android.ui.sports_service_detail.SportsServiceDetailActivity
 import com.seoulfitu.android.ui.sports_service_list.viewmodel.SportsServiceListViewModel
+import com.seoulfitu.android.ui.uimodel.UiSelectedOptions
+import com.seoulfitu.android.util.getParcelableExtraCompat
 import com.seoulfitu.android.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -16,6 +21,13 @@ class SportsServiceListActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivitySportsServiceListBinding
     private val viewModel: SportsServiceListViewModel by viewModels()
+    private val getFilterOptions =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                val options = result.data?.getParcelableExtraCompat<UiSelectedOptions>(FILTER_KEY)!!
+                viewModel.applyOptions(options)
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,7 +64,16 @@ class SportsServiceListActivity : AppCompatActivity() {
 
     private fun setUpView() {
         binding.etSportsServiceListSearch.doOnTextChanged { text, _, _, _ ->
-            viewModel.searchData(text.toString())
+            viewModel.updateSearchKeyword(text.toString())
         }
+        binding.onClickSearch = { viewModel.searchData() }
+        binding.onClickFilter = {
+            val intent = Intent(this, SportsServiceFilterActivity::class.java)
+            getFilterOptions.launch(intent)
+        }
+    }
+
+    companion object {
+        private val FILTER_KEY = "filter"
     }
 }

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/SportsServiceListActivity.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/SportsServiceListActivity.kt
@@ -1,6 +1,5 @@
 package com.seoulfitu.android.ui.sports_service_list
 
-import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
@@ -68,12 +67,12 @@ class SportsServiceListActivity : AppCompatActivity() {
         }
         binding.onClickSearch = { viewModel.searchData() }
         binding.onClickFilter = {
-            val intent = Intent(this, SportsServiceFilterActivity::class.java)
+            val intent = SportsServiceFilterActivity.getIntent(this, viewModel.uiState.value?.selectedOptions!!)
             getFilterOptions.launch(intent)
         }
     }
 
     companion object {
-        private val FILTER_KEY = "filter"
+        private const val FILTER_KEY = "filter"
     }
 }

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/uistate/SportsServiceListUiState.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/uistate/SportsServiceListUiState.kt
@@ -1,10 +1,12 @@
 package com.seoulfitu.android.ui.sports_service_list.uistate
 
+import com.seoulfitu.android.ui.uimodel.UiSelectedOptions
 import com.seoulfitu.android.ui.uimodel.UiSportsService
 
 
 data class SportsServiceListUiState(
     val isSuccess: Boolean? = null,
     val result: List<UiSportsService> = listOf(),
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val selectedOptions: UiSelectedOptions = UiSelectedOptions(cities = listOf(), parking = listOf())
 )

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/viewmodel/SportsServiceListViewModel.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/viewmodel/SportsServiceListViewModel.kt
@@ -4,8 +4,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.seoulfitu.android.domain.model.Coordinate
+import com.seoulfitu.android.domain.model.RegionsWithCoordinate
+import com.seoulfitu.android.domain.repository.GeocodingRepository
 import com.seoulfitu.android.domain.repository.SportsServiceRepository
 import com.seoulfitu.android.ui.sports_service_list.uistate.SportsServiceListUiState
+import com.seoulfitu.android.ui.uimodel.UiSelectedOptions
 import com.seoulfitu.android.ui.uimodel.UiSportsService
 import com.seoulfitu.android.ui.uimodel.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,9 +17,17 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SportsServiceListViewModel @Inject constructor(private val sportsServiceRepository: SportsServiceRepository) :
+class SportsServiceListViewModel @Inject constructor(
+    private val sportsServiceRepository: SportsServiceRepository,
+    private val geocodingRepository: GeocodingRepository
+) :
     ViewModel() {
+    // 전체 서비스
     private var services: List<UiSportsService> = listOf()
+
+    // 검색 결과
+    private var searchedServices: List<UiSportsService> = listOf()
+    private var searchKeyword: String = ""
     private val _uiState: MutableLiveData<SportsServiceListUiState> = MutableLiveData()
     val uiState: LiveData<SportsServiceListUiState> = _uiState
     fun getServices() {
@@ -23,9 +35,13 @@ class SportsServiceListViewModel @Inject constructor(private val sportsServiceRe
             val result = sportsServiceRepository.getServices()
             result.onSuccess {
                 services = it.toUi()
+                searchedServices = services
                 _uiState.value = SportsServiceListUiState(
                     isSuccess = true, result = services
                 )
+                services.forEach { service ->
+                    reverseGeocode(service)
+                }
             }.onFailure {
                 _uiState.value = SportsServiceListUiState(
                     isSuccess = false, errorMessage = it.message
@@ -34,8 +50,54 @@ class SportsServiceListViewModel @Inject constructor(private val sportsServiceRe
         }
     }
 
-    fun searchData(text: String) {
-        val results = services.filter { it.info.title.contains(text) }
+    private suspend fun reverseGeocode(service: UiSportsService) {
+        viewModelScope.launch {
+            val result = geocodingRepository.reverseGeocode(
+                Coordinate(service.info.xCoordinate, service.info.yCoordinate)
+            )
+            result.onSuccess {
+                service.info.address = formatRegion(it)
+            }
+        }
+
+    }
+
+    private fun formatRegion(regionsWithCoordinate: RegionsWithCoordinate): String {
+        regionsWithCoordinate.values[0].apply {
+            return "${area1.name} ${area2.name} ${area3.name} ${area4.name}"
+        }
+    }
+
+    fun updateSearchKeyword(text: String) {
+        searchKeyword = text
+    }
+
+    fun searchData() {
+        val results = services.filter { it.info.title.contains(searchKeyword) }
+        searchedServices = results
+        _uiState.value = SportsServiceListUiState(
+            isSuccess = true, result = searchedServices
+        )
+    }
+
+    fun applyOptions(options: UiSelectedOptions) {
+        val results = searchedServices.filter { service ->
+            val cityFit = if (options.cities.isEmpty()) true else options.cities.any { city ->
+                service.info.address.contains(city)
+            }
+
+            val serviceFit = if (options.services.isEmpty()) true else options.services.any { serviceOption ->
+                service.info.subCategory.contains(serviceOption)
+            }
+            val priceFit = if (options.price.isEmpty()) true else options.price.any { price ->
+                service.info.payment.contains(price)
+            }
+            val serviceStatusFit = if (options.serviceStatus.isEmpty()) true else options.serviceStatus.any { status ->
+                service.info.status.replace(" ", "").contains(status.replace(" ", ""))
+            }
+
+            cityFit and serviceFit /*and priceFit and serviceStatusFit*/
+        }
         _uiState.value = SportsServiceListUiState(
             isSuccess = true, result = results
         )

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/viewmodel/SportsServiceListViewModel.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/viewmodel/SportsServiceListViewModel.kt
@@ -24,7 +24,6 @@ class SportsServiceListViewModel @Inject constructor(
     ViewModel() {
     // 전체 서비스
     private var services: List<UiSportsService> = listOf()
-
     // 검색 결과
     private var searchedServices: List<UiSportsService> = listOf()
     private var searchKeyword: String = ""
@@ -96,7 +95,7 @@ class SportsServiceListViewModel @Inject constructor(
                 service.info.status.replace(" ", "").contains(status.replace(" ", ""))
             }
 
-            cityFit and serviceFit /*and priceFit and serviceStatusFit*/
+            cityFit and serviceFit and priceFit and serviceStatusFit /*and priceFit and serviceStatusFit*/
         }
         _uiState.value = SportsServiceListUiState(
             isSuccess = true, result = results

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/viewmodel/SportsServiceListViewModel.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_list/viewmodel/SportsServiceListViewModel.kt
@@ -24,6 +24,7 @@ class SportsServiceListViewModel @Inject constructor(
     ViewModel() {
     // 전체 서비스
     private var services: List<UiSportsService> = listOf()
+
     // 검색 결과
     private var searchedServices: List<UiSportsService> = listOf()
     private var searchKeyword: String = ""
@@ -98,7 +99,7 @@ class SportsServiceListViewModel @Inject constructor(
             cityFit and serviceFit and priceFit and serviceStatusFit /*and priceFit and serviceStatusFit*/
         }
         _uiState.value = SportsServiceListUiState(
-            isSuccess = true, result = results
+            isSuccess = true, result = results, selectedOptions = options
         )
     }
 }

--- a/app/src/main/java/com/seoulfitu/android/ui/uimodel/UiSelectedOptions.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/uimodel/UiSelectedOptions.kt
@@ -8,7 +8,7 @@ data class UiSelectedOptions(
     val cities: List<String>,
     val facilities: List<String> = listOf(),
     val services: List<String> = listOf(),
-    val parking: List<String> = listOf(),
+    val parking: List<String>,
     val rent: List<String> = listOf(),
     val price: List<String> = listOf(),
     val serviceStatus: List<String> = listOf(),

--- a/app/src/main/java/com/seoulfitu/android/ui/uimodel/UiSelectedOptions.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/uimodel/UiSelectedOptions.kt
@@ -8,7 +8,7 @@ data class UiSelectedOptions(
     val cities: List<String>,
     val facilities: List<String> = listOf(),
     val services: List<String> = listOf(),
-    val parking: List<String>,
+    val parking: List<String> = listOf(),
     val rent: List<String> = listOf(),
     val price: List<String> = listOf(),
     val serviceStatus: List<String> = listOf(),

--- a/app/src/main/java/com/seoulfitu/android/ui/uimodel/UiSportsService.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/uimodel/UiSportsService.kt
@@ -18,7 +18,7 @@ data class UiSportsServiceInfo(
     val img: String = "",
     val status: String = "",
     val subCategory: String = "",
-    val address: String = "",
+    var address: String = "",
     val url: String = "",
     val phoneNumber: String = "",
     val registrationStartDate: String = "",

--- a/app/src/main/res/layout/activity_sports_service_filter.xml
+++ b/app/src/main/res/layout/activity_sports_service_filter.xml
@@ -50,14 +50,6 @@
                     android:layout_marginEnd="24dp" />
 
                 <com.seoulfitu.android.ui.filter.FilterCustomView
-                    android:id="@+id/cv_service_filter_parking"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="24dp"
-                    android:layout_marginTop="24dp"
-                    android:layout_marginEnd="24dp" />
-
-                <com.seoulfitu.android.ui.filter.FilterCustomView
                     android:id="@+id/cv_service_filter_status"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_sports_service_list.xml
+++ b/app/src/main/res/layout/activity_sports_service_list.xml
@@ -3,6 +3,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+        <variable
+            name="onClickFilter"
+            type="kotlin.jvm.functions.Function0" />
+        <variable
+            name="onClickSearch"
+            type="kotlin.jvm.functions.Function0" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -72,6 +81,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="10dp"
                 android:src="@drawable/ic_search"
+                android:onClick="@{()->onClickSearch.invoke()}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/et_sports_service_list_search"
@@ -85,6 +95,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin_default"
             android:src="@drawable/ic_filter"
+            android:onClick="@{()->onClickFilter.invoke()}"
             app:layout_constraintBottom_toBottomOf="@+id/cl_sports_service_list_search"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/cl_sports_service_list_search"


### PR DESCRIPTION
## 📌 관련 이슈
- #26 

## 🛠️ 작업 내용
- [X] 공공서비스 필터 선택 후 돌아올 때 선택된 옵션의 서비스들만 보여준다.
- [X] 옵션 재선택시 이전 선택 옵션을 SportsServiceFilterActivity 에 다시 띄워준다.

## 🎯 리뷰 포인트
- 필터 적용 시 주소가 필요하기 때문에 기존에 `SportsServiceDetailViewModel` 에서 담당했던 `reverseGeocode` 로직을 `SportsServiceListViewModel` 에서 담당하도록 수정하였습니다. 
- 서비스 목록을 불러오고 각 서비스에 대해서 reverseGeocode 를 실행해줘야 하는데 동기적으로 하면 너무 많은 시간이 걸리기 때문에 viewModelScope 를 launch 해서 reverseGeocode 를 실행함으로써 비동기적으로 수행되도록 코드를 작성했습니다. 근데 잘 작성한건지 모르겠어용 ㅎㅎ 코틀린 코루틴 스터디 시급 ><

## 💻 미완료 태스크
