### PR TITLE
[fix] 공공 체육 서비스 리스트 스크랩 후 갱신 오류 수정 (#43)

### DIFF
--- a/app/src/main/java/com/seoulfitu/android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/main/MainViewModel.kt
@@ -90,7 +90,7 @@ class MainViewModel @Inject constructor(
             }.onSuccess { facilities ->
                 _scrapedFacilities.postValue(facilities.map { it.toUi(true) })
             }.onFailure {
-                _throwable.value = it.message
+                _throwable.postValue(it.message)
             }
         }
     }
@@ -102,7 +102,7 @@ class MainViewModel @Inject constructor(
             }.onSuccess { services ->
                 _scrapedServices.postValue(services.map { it.toUi() }.map { it.copy(scrapped = true) })
             }.onFailure {
-                _throwable.value = it.message
+                _throwable.postValue(it.message)
             }
         }
     }

--- a/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/SportsServiceDetailActivity.kt
+++ b/app/src/main/java/com/seoulfitu/android/ui/sports_service_detail/SportsServiceDetailActivity.kt
@@ -3,6 +3,7 @@ package com.seoulfitu.android.ui.sports_service_detail
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.seoulfitu.android.databinding.ActivitySportsServiceDetailBinding
@@ -27,6 +28,7 @@ class SportsServiceDetailActivity : AppCompatActivity() {
         getIntentExtra()
         observeSportsService()
         setClickListeners()
+        addOnBackPressedCallback()
     }
 
     private fun getIntentExtra() {
@@ -46,10 +48,16 @@ class SportsServiceDetailActivity : AppCompatActivity() {
             viewModel.scrapService()
             flag = true
         }
-        binding.ivSportsServiceDetailBack.setOnClickListener {
-            if (flag) setResult(RESULT_OK)
-            finish()
+    }
+
+    private fun addOnBackPressedCallback() {
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (flag) setResult(RESULT_OK)
+                finish()
+            }
         }
+        onBackPressedDispatcher.addCallback(this, callback)
     }
 
     private fun setScrapStatue() {

--- a/app/src/main/res/layout/activity_sports_service_detail.xml
+++ b/app/src/main/res/layout/activity_sports_service_detail.xml
@@ -20,16 +20,6 @@
             tools:context="com.seoulfitu.android.ui.sports_service_detail.SportsServiceDetailActivity">
 
             <ImageView
-                android:id="@+id/iv_sports_service_detail_back"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="@dimen/margin_default"
-                android:layout_marginTop="20dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/ic_back" />
-
-            <ImageView
                 android:id="@+id/iv_sports_service_detail_scrap"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #43 

## 🛠️ 작업 내용
- [X] 공공 체육 서비스 리스트 스크랩 후 갱신 오류 수정

## 🎯 리뷰 포인트
- `onBackPressed` 가 API 33부터 deprecated 되어서 `onBackPressedCallback`을 사용했습니다! 자세한 내용은 이슈 `학습 내용`에 적어놓았습니다
- 잘 동작 되는지 확인해주세요!🥰
